### PR TITLE
chore: use clipfree as a pypi package ('horde_clipfree')

### DIFF
--- a/hordelib/benchmark.py
+++ b/hordelib/benchmark.py
@@ -89,7 +89,7 @@ def main():
             model_dir = os.path.join(os.getcwd())
         elif os.path.exists("bridgeData.yaml"):
             # try the worker yaml
-            with open("bridgeData.yaml", "rt", encoding="utf-8") as configfile:
+            with open("bridgeData.yaml", encoding="utf-8") as configfile:
                 data = yaml.safe_load(configfile)
                 model_dir = data.get("cache_home", "")
                 if not model_dir:

--- a/requirements.txt
+++ b/requirements.txt
@@ -40,4 +40,4 @@ scikit-image
 mediapipe>=0.9.1.0
 unidecode
 fuzzywuzzy
-clipfree @ git+https://github.com/db0/clipfree
+horde_clipfree


### PR DESCRIPTION
This side steps pypi's restrictions with using git repos as package sources.