### PR TITLE
fix: remove some unneeded logger messages

### DIFF
--- a/hordelib/horde.py
+++ b/hordelib/horde.py
@@ -295,11 +295,9 @@ class HordeLib:
             # Remove any requested LORAs that we don't have
             valid_loras = []
             for lora in payload.get("loras"):
-                logger.error(lora)
                 # Determine the actual lora filename
                 if not SharedModelManager.manager.lora.is_local_model(str(lora["name"])):
                     adhoc_lora = SharedModelManager.manager.lora.fetch_adhoc_lora(str(lora["name"]))
-                    logger.error(adhoc_lora)
                     if not adhoc_lora:
                         logger.info(f"Adhoc lora requested '{lora['name']}' could not be found in CivitAI. Ignoring!")
                         continue
@@ -328,7 +326,6 @@ class HordeLib:
                     SharedModelManager.manager.lora.touch_lora(lora_name)
                     valid_loras.append(lora)
             payload["loras"] = valid_loras
-            logger.error(valid_loras)
             for lora_index, lora in enumerate(payload.get("loras")):
 
                 # Inject a lora node (first lora)


### PR DESCRIPTION
3 logger.error() calls slipped through that were for debugging purposes. This removes them, as they may be confusing to a user.