### PR TITLE
fix: actually attempt to redownload on hash mismatch

### DIFF
--- a/hordelib/model_manager/base.py
+++ b/hordelib/model_manager/base.py
@@ -526,6 +526,7 @@ class BaseModelManager(ABC):
                     # The file must have been considered valid once, or we wouldn't have renamed
                     # it from the ".part" download. Likely there is an update, or a model database hash problem
                     logger.warning(f"Likely updated, will attempt to re-download {file_details['path']}.")
+                    self.taint_model(model_name)
                 except OSError as e:
                     logger.error(f"Unable to delete {file_details['path']}: {e}.")
                     logger.error(f"Please delete {file_details['path']} if this error persists.")

--- a/tests/model_managers/test_shared_model_manager.py
+++ b/tests/model_managers/test_shared_model_manager.py
@@ -44,7 +44,9 @@ class TestSharedModelManager:
         result: bool | None = shared_model_manager.manager.validate_model("Deliberate")
         assert result is True
         shared_model_manager.manager.unload_model("Deliberate")
-        assert shared_model_manager.manager.validate_model("Deliberate")
+        if not shared_model_manager.manager.validate_model("Deliberate"):
+            assert shared_model_manager.manager.download_model("Deliberate")
+            assert shared_model_manager.manager.validate_model("Deliberate")
 
     def test_taint_models(
         self,
@@ -115,7 +117,9 @@ class TestSharedModelManager:
         assert shared_model_manager.manager is not None
         for model_manager in shared_model_manager.manager.active_model_managers:
             for model in model_manager.available_models:
-                assert model_manager.validate_model(model)
+                if not model_manager.validate_model(model):
+                    assert model_manager.download_model(model)
+                    assert model_manager.validate_model(model)
 
     def test_preload_annotators(
         self,


### PR DESCRIPTION
Use the up-until-now unused taint function to prompt a redownload of models whose hashes have changed in the model reference.