### PR TITLE
fix: remove rlimit hack from 3rd party module

### DIFF
--- a/hordelib/nodes/comfy_controlnet_preprocessors/uniformer/mmseg/datasets/builder.py
+++ b/hordelib/nodes/comfy_controlnet_preprocessors/uniformer/mmseg/datasets/builder.py
@@ -10,15 +10,18 @@ from comfy_controlnet_preprocessors.uniformer.mmcv.runner import get_dist_info
 from comfy_controlnet_preprocessors.uniformer.mmcv.utils import Registry, build_from_cfg
 from comfy_controlnet_preprocessors.uniformer.mmcv.utils.parrots_wrapper import DataLoader, PoolDataLoader
 from torch.utils.data import DistributedSampler
+import torch
 
 if platform.system() != "Windows":
-    # https://github.com/pytorch/pytorch/issues/973
-    import resource
+    torch.multiprocessing.set_sharing_strategy("file_system")
+# if platform.system() != "Windows":
+#     # https://github.com/pytorch/pytorch/issues/973
+#     import resource
 
-    rlimit = resource.getrlimit(resource.RLIMIT_NOFILE)
-    hard_limit = rlimit[1]
-    soft_limit = min(4096, hard_limit)
-    resource.setrlimit(resource.RLIMIT_NOFILE, (soft_limit, hard_limit))
+#     rlimit = resource.getrlimit(resource.RLIMIT_NOFILE)
+#     hard_limit = rlimit[1]
+#     soft_limit = min(4096, hard_limit)
+#     resource.setrlimit(resource.RLIMIT_NOFILE, (soft_limit, hard_limit))
 
 DATASETS = Registry("dataset", sys.modules[__name__])
 PIPELINES = Registry("pipeline", sys.modules[__name__])


### PR DESCRIPTION
It seems that the 3rd party annotators were relying on setting rlimits to do... something? It is unclear to me why such a potentially disruptive system change was casually invoked. The offending file was `hordelib\nodes\comfy_controlnet_preprocessors\uniformer\mmseg\datasets\builder.py`.

Long story short, certain hosted environments, such as runpod, forbid adjusting rlimits. This means certain cloud workers are unable to run hordelib.

See also https://github.com/pytorch/pytorch/issues/973 for some background on the solution I adopted here, which strangely enough is reference in the code removed. I don't have the mental bandwidth to parse the purpose of this module, so it remains to be seen if this change will work in practice. 
