### PR TITLE
refactor: Improved type hints, various fixes, removes loguru hijacks

### DIFF
--- a/examples/run_all_models.py
+++ b/examples/run_all_models.py
@@ -7,6 +7,7 @@ import hordelib
 
 hordelib.initialise(setup_logging=False)
 
+from hordelib.consts import MODEL_CATEGORY_NAMES
 from hordelib.horde import HordeLib
 from hordelib.shared_model_manager import SharedModelManager
 
@@ -60,7 +61,7 @@ def do_inference(model_name, iterations=1):
 
 def main():
     HordeLib()
-    SharedModelManager.loadModelManagers(compvis=True)
+    SharedModelManager.load_model_managers([MODEL_CATEGORY_NAMES.compvis])
 
     os.makedirs("images/all_models/", exist_ok=True)
 

--- a/examples/run_controlnet.py
+++ b/examples/run_controlnet.py
@@ -4,6 +4,7 @@
 import os
 
 import hordelib
+from hordelib.consts import MODEL_CATEGORY_NAMES
 
 
 def main():
@@ -16,7 +17,7 @@ def main():
     from hordelib.shared_model_manager import SharedModelManager
 
     generate = HordeLib()
-    SharedModelManager.loadModelManagers(compvis=True, controlnet=True)
+    SharedModelManager.load_model_managers([MODEL_CATEGORY_NAMES.compvis, MODEL_CATEGORY_NAMES.controlnet])
     SharedModelManager.manager.load("Deliberate")
 
     data = {

--- a/examples/run_controlnet_annotator.py
+++ b/examples/run_controlnet_annotator.py
@@ -4,6 +4,7 @@
 import os
 
 import hordelib
+from hordelib.consts import MODEL_CATEGORY_NAMES
 
 
 def main():
@@ -16,7 +17,7 @@ def main():
     from hordelib.shared_model_manager import SharedModelManager
 
     generate = HordeLib()
-    SharedModelManager.loadModelManagers(compvis=True, controlnet=True)
+    SharedModelManager.load_model_managers([MODEL_CATEGORY_NAMES.compvis, MODEL_CATEGORY_NAMES.controlnet])
 
     data = {
         "sampler_name": "k_dpmpp_2m",

--- a/examples/run_facefix.py
+++ b/examples/run_facefix.py
@@ -11,20 +11,22 @@ def main():
 
     from PIL import Image
 
+    from hordelib.consts import MODEL_CATEGORY_NAMES
     from hordelib.horde import HordeLib
     from hordelib.shared_model_manager import SharedModelManager
 
     generate = HordeLib()
-    modeltypes = {
-        "codeformer": True,
-        "compvis": True,
-        "controlnet": True,
-        "esrgan": True,
-        "gfpgan": True,
-        "safety_checker": True,
-    }
 
-    SharedModelManager.loadModelManagers(**modeltypes)
+    SharedModelManager.load_model_managers(
+        [
+            MODEL_CATEGORY_NAMES.codeformer,
+            MODEL_CATEGORY_NAMES.compvis,
+            MODEL_CATEGORY_NAMES.controlnet,
+            MODEL_CATEGORY_NAMES.esrgan,
+            MODEL_CATEGORY_NAMES.gfpgan,
+            MODEL_CATEGORY_NAMES.safety_checker,
+        ],
+    )
     SharedModelManager.manager.load("CodeFormers")
 
     data = {

--- a/examples/run_img2img.py
+++ b/examples/run_img2img.py
@@ -4,6 +4,7 @@
 import os
 
 import hordelib
+from hordelib.consts import MODEL_CATEGORY_NAMES
 
 
 def main():
@@ -15,7 +16,7 @@ def main():
     from hordelib.shared_model_manager import SharedModelManager
 
     generate = HordeLib()
-    SharedModelManager.loadModelManagers(compvis=True)
+    SharedModelManager.load_model_managers([MODEL_CATEGORY_NAMES.compvis])
     SharedModelManager.manager.load("Deliberate")
 
     data = {

--- a/examples/run_img2img_hires.py
+++ b/examples/run_img2img_hires.py
@@ -4,6 +4,7 @@
 import os
 
 import hordelib
+from hordelib.consts import MODEL_CATEGORY_NAMES
 
 
 def main():
@@ -16,7 +17,7 @@ def main():
     from hordelib.shared_model_manager import SharedModelManager
 
     generate = HordeLib()
-    SharedModelManager.loadModelManagers(compvis=True)
+    SharedModelManager.load_model_managers([MODEL_CATEGORY_NAMES.compvis])
     SharedModelManager.manager.load("Deliberate")
 
     data = {

--- a/examples/run_img2img_inpaint.py
+++ b/examples/run_img2img_inpaint.py
@@ -4,6 +4,7 @@
 import os
 
 import hordelib
+from hordelib.consts import MODEL_CATEGORY_NAMES
 
 
 def main():
@@ -15,7 +16,7 @@ def main():
     from hordelib.shared_model_manager import SharedModelManager
 
     generate = HordeLib()
-    SharedModelManager.loadModelManagers(compvis=True)
+    SharedModelManager.load_model_managers([MODEL_CATEGORY_NAMES.compvis])
     SharedModelManager.manager.load("Deliberate")
 
     data = {

--- a/examples/run_img2img_inpaint_mask.py
+++ b/examples/run_img2img_inpaint_mask.py
@@ -4,6 +4,7 @@
 import os
 
 import hordelib
+from hordelib.consts import MODEL_CATEGORY_NAMES
 
 
 def main():
@@ -15,7 +16,7 @@ def main():
     from hordelib.shared_model_manager import SharedModelManager
 
     generate = HordeLib()
-    SharedModelManager.loadModelManagers(compvis=True)
+    SharedModelManager.load_model_managers([MODEL_CATEGORY_NAMES.compvis])
     SharedModelManager.manager.load("stable_diffusion_inpainting")
 
     data = {

--- a/examples/run_img2img_mask.py
+++ b/examples/run_img2img_mask.py
@@ -4,6 +4,7 @@
 import os
 
 import hordelib
+from hordelib.consts import MODEL_CATEGORY_NAMES
 
 
 def main():
@@ -15,7 +16,7 @@ def main():
     from hordelib.shared_model_manager import SharedModelManager
 
     generate = HordeLib()
-    SharedModelManager.loadModelManagers(compvis=True)
+    SharedModelManager.load_model_managers([MODEL_CATEGORY_NAMES.compvis])
     SharedModelManager.manager.load("Deliberate")
 
     data = {

--- a/examples/run_img2img_outpaint.py
+++ b/examples/run_img2img_outpaint.py
@@ -4,6 +4,7 @@
 import os
 
 import hordelib
+from hordelib.consts import MODEL_CATEGORY_NAMES
 
 
 def main():
@@ -15,7 +16,7 @@ def main():
     from hordelib.shared_model_manager import SharedModelManager
 
     generate = HordeLib()
-    SharedModelManager.loadModelManagers(compvis=True)
+    SharedModelManager.load_model_managers([MODEL_CATEGORY_NAMES.compvis])
     SharedModelManager.manager.load("Deliberate")
 
     data = {

--- a/examples/run_inpainting.py
+++ b/examples/run_inpainting.py
@@ -4,6 +4,7 @@
 import os
 
 import hordelib
+from hordelib.consts import MODEL_CATEGORY_NAMES
 
 
 def main():
@@ -15,7 +16,7 @@ def main():
     from hordelib.shared_model_manager import SharedModelManager
 
     generate = HordeLib()
-    SharedModelManager.loadModelManagers(compvis=True)
+    SharedModelManager.load_model_managers([MODEL_CATEGORY_NAMES.compvis])
     SharedModelManager.manager.load("stable_diffusion_inpainting")
 
     data = {

--- a/examples/run_kudos_test.py
+++ b/examples/run_kudos_test.py
@@ -15,6 +15,7 @@ import hordelib
 hordelib.initialise(setup_logging=True, clear_logs=True)
 
 from hordelib.comfy_horde import cleanup
+from hordelib.consts import MODEL_CATEGORY_NAMES
 from hordelib.horde import HordeLib
 from hordelib.settings import UserSettings
 from hordelib.shared_model_manager import SharedModelManager
@@ -76,7 +77,15 @@ def calculate_kudos_cost(base_time, job_data):
 
 def main():
     horde = HordeLib()
-    SharedModelManager.loadModelManagers(compvis=True, controlnet=True, esrgan=True, gfpgan=True, codeformer=True)
+    SharedModelManager.load_model_managers(
+        [
+            MODEL_CATEGORY_NAMES.compvis,
+            MODEL_CATEGORY_NAMES.controlnet,
+            MODEL_CATEGORY_NAMES.esrgan,
+            MODEL_CATEGORY_NAMES.gfpgan,
+            MODEL_CATEGORY_NAMES.codeformer,
+        ],
+    )
 
     add_model("stable_diffusion")
 

--- a/examples/run_long_prompt_check.py
+++ b/examples/run_long_prompt_check.py
@@ -4,6 +4,7 @@ import time
 from loguru import logger
 
 import hordelib
+from hordelib.consts import MODEL_CATEGORY_NAMES
 
 metrics = {}
 last_label = ""
@@ -30,7 +31,7 @@ def main():
     from hordelib.shared_model_manager import SharedModelManager
 
     generate = HordeLib()
-    SharedModelManager.loadModelManagers(compvis=True)
+    SharedModelManager.load_model_managers([MODEL_CATEGORY_NAMES.compvis])
     SharedModelManager.manager.load("Deliberate")
 
     # As basic as we can get data

--- a/examples/run_lora.py
+++ b/examples/run_lora.py
@@ -9,11 +9,17 @@ import hordelib
 def main():
     hordelib.initialise(setup_logging=False)
 
+    from hordelib.consts import MODEL_CATEGORY_NAMES
     from hordelib.horde import HordeLib
     from hordelib.shared_model_manager import SharedModelManager
 
     generate = HordeLib()
-    SharedModelManager.loadModelManagers(compvis=True, lora=True)
+    SharedModelManager.load_model_managers(
+        [
+            MODEL_CATEGORY_NAMES.compvis,
+            MODEL_CATEGORY_NAMES.lora,
+        ],
+    )
     SharedModelManager.manager.lora.download_default_loras()
     SharedModelManager.manager.lora.wait_for_downloads()
     SharedModelManager.manager.load("Deliberate")

--- a/examples/run_memory_test.py
+++ b/examples/run_memory_test.py
@@ -10,6 +10,7 @@ import psutil
 from loguru import logger
 
 import hordelib
+from hordelib.consts import MODEL_CATEGORY_NAMES
 
 hordelib.initialise(setup_logging=False)
 
@@ -109,7 +110,7 @@ def do_background_inference():
 def main():
     HordeLib()
     GPUInfo()
-    SharedModelManager.loadModelManagers(compvis=True)
+    SharedModelManager.load_model_managers([MODEL_CATEGORY_NAMES.compvis])
 
     report_ram()
 

--- a/examples/run_stress_test_cnet.py
+++ b/examples/run_stress_test_cnet.py
@@ -10,6 +10,8 @@ import time
 from loguru import logger
 from PIL import Image
 
+from hordelib.consts import MODEL_CATEGORY_NAMES
+
 if __name__ != "__main__":
     exit(0)
 
@@ -37,7 +39,7 @@ out_dir = f"images/stresstest/{os.path.splitext(os.path.basename(sys.argv[0]))[0
 os.makedirs(out_dir, exist_ok=True)
 
 generate = HordeLib()
-SharedModelManager.loadModelManagers(compvis=True, controlnet=True)
+SharedModelManager.load_model_managers([MODEL_CATEGORY_NAMES.compvis, MODEL_CATEGORY_NAMES.controlnet])
 
 models = ["Deliberate", "Anything Diffusion", "Realistic Vision", "URPM"]
 cnets = ["canny", "hed", "fakescribbles", "depth", "normal", "hough"]

--- a/examples/run_stress_test_cnet_preproc.py
+++ b/examples/run_stress_test_cnet_preproc.py
@@ -10,6 +10,8 @@ import time
 from loguru import logger
 from PIL import Image
 
+from hordelib.consts import MODEL_CATEGORY_NAMES
+
 if __name__ != "__main__":
     exit(0)
 
@@ -37,7 +39,7 @@ out_dir = f"images/stresstest/{os.path.splitext(os.path.basename(sys.argv[0]))[0
 os.makedirs(out_dir, exist_ok=True)
 
 generate = HordeLib()
-SharedModelManager.loadModelManagers(compvis=True, controlnet=True)
+SharedModelManager.load_model_managers([MODEL_CATEGORY_NAMES.compvis, MODEL_CATEGORY_NAMES.controlnet])
 SharedModelManager.manager.load("Deliberate")
 SharedModelManager.manager.load("Anything Diffusion")
 SharedModelManager.manager.load("Realistic Vision")

--- a/examples/run_stress_test_dynamic.py
+++ b/examples/run_stress_test_dynamic.py
@@ -10,6 +10,8 @@ import time
 from loguru import logger
 from PIL import Image
 
+from hordelib.consts import MODEL_CATEGORY_NAMES
+
 if __name__ != "__main__":
     exit(0)
 
@@ -37,7 +39,7 @@ out_dir = f"images/stresstest/{os.path.splitext(os.path.basename(sys.argv[0]))[0
 os.makedirs(out_dir, exist_ok=True)
 
 generate = HordeLib()
-SharedModelManager.loadModelManagers(compvis=True, controlnet=True)
+SharedModelManager.load_model_managers([MODEL_CATEGORY_NAMES.compvis, MODEL_CATEGORY_NAMES.controlnet])
 
 initmodels = [
     random.choice(SharedModelManager.manager.compvis.available_models),

--- a/examples/run_stress_test_img2img.py
+++ b/examples/run_stress_test_img2img.py
@@ -10,6 +10,8 @@ import time
 from loguru import logger
 from PIL import Image
 
+from hordelib.consts import MODEL_CATEGORY_NAMES
+
 if __name__ != "__main__":
     exit(0)
 
@@ -37,7 +39,7 @@ out_dir = f"images/stresstest/{os.path.splitext(os.path.basename(sys.argv[0]))[0
 os.makedirs(out_dir, exist_ok=True)
 
 generate = HordeLib()
-SharedModelManager.loadModelManagers(compvis=True, controlnet=True)
+SharedModelManager.load_model_managers([MODEL_CATEGORY_NAMES.compvis, MODEL_CATEGORY_NAMES.controlnet])
 SharedModelManager.manager.load("Deliberate")
 SharedModelManager.manager.load("Anything Diffusion")
 SharedModelManager.manager.load("Realistic Vision")

--- a/examples/run_stress_test_job_collection.py
+++ b/examples/run_stress_test_job_collection.py
@@ -16,6 +16,7 @@ if __name__ != "__main__":
 import hordelib
 
 hordelib.initialise(setup_logging=False)
+from hordelib.consts import MODEL_CATEGORY_NAMES
 from hordelib.horde import HordeLib
 from hordelib.settings import UserSettings
 from hordelib.shared_model_manager import SharedModelManager
@@ -52,13 +53,15 @@ out_dir = f"images/stresstest/{os.path.splitext(os.path.basename(sys.argv[0]))[0
 os.makedirs(out_dir, exist_ok=True)
 
 generate = HordeLib()
-SharedModelManager.loadModelManagers(
-    compvis=True,
-    controlnet=True,
-    codeformer=True,
-    esrgan=True,
-    gfpgan=True,
-    lora=True,
+SharedModelManager.load_model_managers(
+    [
+        MODEL_CATEGORY_NAMES.compvis,
+        MODEL_CATEGORY_NAMES.controlnet,
+        MODEL_CATEGORY_NAMES.codeformer,
+        MODEL_CATEGORY_NAMES.esrgan,
+        MODEL_CATEGORY_NAMES.gfpgan,
+        MODEL_CATEGORY_NAMES.lora,
+    ],
 )
 if DOWNLOAD_LORAS:
     SharedModelManager.manager.lora.download_default_loras()

--- a/examples/run_stress_test_mixed.py
+++ b/examples/run_stress_test_mixed.py
@@ -16,6 +16,7 @@ if __name__ != "__main__":
 import hordelib
 
 hordelib.initialise(setup_logging=False)
+from hordelib.consts import MODEL_CATEGORY_NAMES
 from hordelib.horde import HordeLib
 from hordelib.shared_model_manager import SharedModelManager
 
@@ -39,7 +40,15 @@ out_dir = f"images/stresstest/{os.path.splitext(os.path.basename(sys.argv[0]))[0
 os.makedirs(out_dir, exist_ok=True)
 
 generate = HordeLib()
-SharedModelManager.loadModelManagers(compvis=True, controlnet=True, codeformer=True, esrgan=True, gfpgan=True)
+SharedModelManager.load_model_managers(
+    [
+        MODEL_CATEGORY_NAMES.codeformer,
+        MODEL_CATEGORY_NAMES.compvis,
+        MODEL_CATEGORY_NAMES.controlnet,
+        MODEL_CATEGORY_NAMES.esrgan,
+        MODEL_CATEGORY_NAMES.gfpgan,
+    ],
+)
 
 models = ["Deliberate", "Anything Diffusion", "Realistic Vision", "URPM"]
 cnets = ["canny", "hed", "fakescribbles", "depth", "normal", "hough"]

--- a/examples/run_stress_test_pp.py
+++ b/examples/run_stress_test_pp.py
@@ -16,6 +16,7 @@ if __name__ != "__main__":
 import hordelib
 
 hordelib.initialise(setup_logging=False)
+from hordelib.consts import MODEL_CATEGORY_NAMES
 from hordelib.horde import HordeLib
 from hordelib.shared_model_manager import SharedModelManager
 
@@ -37,7 +38,13 @@ out_dir = f"images/stresstest/{os.path.splitext(os.path.basename(sys.argv[0]))[0
 os.makedirs(out_dir, exist_ok=True)
 
 generate = HordeLib()
-SharedModelManager.loadModelManagers(codeformer=True, esrgan=True, gfpgan=True)
+SharedModelManager.load_model_managers(
+    [
+        MODEL_CATEGORY_NAMES.compvis,
+        MODEL_CATEGORY_NAMES.esrgan,
+        MODEL_CATEGORY_NAMES.gfpgan,
+    ],
+)
 models = [
     "CodeFormers",
     "GFPGAN",

--- a/examples/run_stress_test_txt2img.py
+++ b/examples/run_stress_test_txt2img.py
@@ -10,6 +10,8 @@ import time
 from loguru import logger
 from PIL import Image
 
+from hordelib.consts import MODEL_CATEGORY_NAMES
+
 if __name__ != "__main__":
     exit(0)
 
@@ -37,7 +39,7 @@ out_dir = f"images/stresstest/{os.path.splitext(os.path.basename(sys.argv[0]))[0
 os.makedirs(out_dir, exist_ok=True)
 
 generate = HordeLib()
-SharedModelManager.loadModelManagers(compvis=True, controlnet=True)
+SharedModelManager.load_model_managers([MODEL_CATEGORY_NAMES.compvis, MODEL_CATEGORY_NAMES.controlnet])
 SharedModelManager.manager.load("Deliberate")
 SharedModelManager.manager.load("Anything Diffusion")
 SharedModelManager.manager.load("Realistic Vision")

--- a/examples/run_stress_test_txt2img_hiresfix.py
+++ b/examples/run_stress_test_txt2img_hiresfix.py
@@ -10,6 +10,8 @@ import time
 from loguru import logger
 from PIL import Image
 
+from hordelib.consts import MODEL_CATEGORY_NAMES
+
 if __name__ != "__main__":
     exit(0)
 
@@ -37,7 +39,7 @@ out_dir = f"images/stresstest/{os.path.splitext(os.path.basename(sys.argv[0]))[0
 os.makedirs(out_dir, exist_ok=True)
 
 generate = HordeLib()
-SharedModelManager.loadModelManagers(compvis=True, controlnet=True)
+SharedModelManager.load_model_managers([MODEL_CATEGORY_NAMES.compvis, MODEL_CATEGORY_NAMES.controlnet])
 SharedModelManager.manager.load("Deliberate")
 SharedModelManager.manager.load("Anything Diffusion")
 SharedModelManager.manager.load("Realistic Vision")

--- a/examples/run_txt2img.py
+++ b/examples/run_txt2img.py
@@ -4,6 +4,7 @@
 import os
 
 import hordelib
+from hordelib.consts import MODEL_CATEGORY_NAMES
 
 
 def main():
@@ -13,7 +14,7 @@ def main():
     from hordelib.shared_model_manager import SharedModelManager
 
     generate = HordeLib()
-    SharedModelManager.loadModelManagers(compvis=True)
+    SharedModelManager.load_model_managers([MODEL_CATEGORY_NAMES.compvis])
     SharedModelManager.manager.load("Deliberate")
 
     data = {

--- a/examples/run_txt2img_hires.py
+++ b/examples/run_txt2img_hires.py
@@ -4,6 +4,7 @@
 import os
 
 import hordelib
+from hordelib.consts import MODEL_CATEGORY_NAMES
 
 
 def main():
@@ -13,7 +14,7 @@ def main():
     from hordelib.shared_model_manager import SharedModelManager
 
     generate = HordeLib()
-    SharedModelManager.loadModelManagers(compvis=True)
+    SharedModelManager.load_model_managers([MODEL_CATEGORY_NAMES.compvis])
     SharedModelManager.manager.load("Deliberate")
 
     data = {

--- a/examples/run_txt2img_local_model.py
+++ b/examples/run_txt2img_local_model.py
@@ -4,6 +4,7 @@
 import os
 
 import hordelib
+from hordelib.consts import MODEL_CATEGORY_NAMES
 
 
 def main():
@@ -13,7 +14,7 @@ def main():
     from hordelib.shared_model_manager import SharedModelManager
 
     generate = HordeLib()
-    SharedModelManager.loadModelManagers(compvis=True)
+    SharedModelManager.load_model_managers([MODEL_CATEGORY_NAMES.compvis])
     localfile = "cyberrealistic_v13.safetensors"
     SharedModelManager.manager.load(localfile, local=True)
 

--- a/examples/run_upscale.py
+++ b/examples/run_upscale.py
@@ -16,15 +16,6 @@ def main():
     from hordelib.shared_model_manager import SharedModelManager
 
     generate = HordeLib()
-    modeltypes = {
-        "codeformer": True,
-        "compvis": True,
-        "controlnet": True,
-        # "diffusers": True,
-        "esrgan": True,
-        "gfpgan": True,
-        "safety_checker": True,
-    }
 
     SharedModelManager.load_model_managers(
         [

--- a/examples/run_upscale.py
+++ b/examples/run_upscale.py
@@ -11,6 +11,7 @@ def main():
 
     from PIL import Image
 
+    from hordelib.consts import MODEL_CATEGORY_NAMES
     from hordelib.horde import HordeLib
     from hordelib.shared_model_manager import SharedModelManager
 
@@ -25,7 +26,16 @@ def main():
         "safety_checker": True,
     }
 
-    SharedModelManager.loadModelManagers(**modeltypes)
+    SharedModelManager.load_model_managers(
+        [
+            MODEL_CATEGORY_NAMES.codeformer,
+            MODEL_CATEGORY_NAMES.compvis,
+            MODEL_CATEGORY_NAMES.controlnet,
+            MODEL_CATEGORY_NAMES.esrgan,
+            MODEL_CATEGORY_NAMES.gfpgan,
+            MODEL_CATEGORY_NAMES.safety_checker,
+        ],
+    )
     SharedModelManager.manager.load("RealESRGAN_x4plus")
 
     data = {

--- a/hordelib/benchmark.py
+++ b/hordelib/benchmark.py
@@ -134,7 +134,7 @@ def main():
 
     generate = HordeLib()
     delta("model-manager-load")
-    SharedModelManager.loadModelManagers(compvis=True, controlnet=not disable_controlnet)
+    SharedModelManager.load_model_managers(compvis=True, controlnet=not disable_controlnet)
     delta("model-manager-load")
     SharedModelManager.manager.load("stable_diffusion")
 

--- a/hordelib/benchmark.py
+++ b/hordelib/benchmark.py
@@ -128,7 +128,7 @@ def main():
     from hordelib.shared_model_manager import SharedModelManager
 
     try:
-        from hordelib._version import __version__
+        from hordelib._version import __version__  # type: ignore
     except Exception:
         __version__ = "dev branch"
 

--- a/hordelib/comfy_horde.py
+++ b/hordelib/comfy_horde.py
@@ -67,7 +67,7 @@ _comfy_validate_prompt: types.ModuleType
 _comfy_folder_paths: types.ModuleType
 __comfy_load_checkpoint_guess_config: types.FunctionType
 __comfy_load_controlnet: types.FunctionType
-_comfy_model_manager: types.ModuleType
+_comfy_model_manager: types.ModuleType | None = None
 __comfy_get_torch_device: types.FunctionType
 __comfy_get_free_memory: types.FunctionType
 __comfy_load_torch_file: types.FunctionType

--- a/hordelib/consts.py
+++ b/hordelib/consts.py
@@ -28,8 +28,11 @@ EXCLUDED_MODEL_NAMES = ["pix2pix"]
 class MODEL_CATEGORY_NAMES(str, Enum):
     """Look up str enum for the categories of models (compvis, controlnet, clip, etc...)."""
 
+    default_models = "default_models"
+    """Unspecified model category."""
     codeformer = "codeformer"
     compvis = "compvis"
+    """Stable Diffusion models."""
     controlnet = "controlnet"
     # diffusers = "diffusers"
     esrgan = "esrgan"

--- a/hordelib/consts.py
+++ b/hordelib/consts.py
@@ -22,7 +22,7 @@ class HordeSupportedBackends(Enum):
 
 # Models Excluded from hordelib (for now) # FIXME
 # this could easily be a json file on the AI-Horde-image-model-reference repo
-EXCLUDED_MODEL_NAMES = ["pix2pix", "anything_v4_inpainting", "dreamlike_diffusion_inpainting"]
+EXCLUDED_MODEL_NAMES = ["pix2pix"]
 
 
 class MODEL_CATEGORY_NAMES(str, Enum):

--- a/hordelib/model_manager/__init__.py
+++ b/hordelib/model_manager/__init__.py
@@ -1,0 +1,3 @@
+from hordelib.model_manager.hyper import MODEL_MANAGERS_TYPE_LOOKUP
+
+__all__ = ["MODEL_MANAGERS_TYPE_LOOKUP"]

--- a/hordelib/model_manager/base.py
+++ b/hordelib/model_manager/base.py
@@ -3,15 +3,13 @@ import importlib.resources as importlib_resources
 import json
 import os
 import shutil
-import sys
 import threading
 import time
 import typing
 import zipfile
 from abc import ABC, abstractmethod
-from contextlib import nullcontext
 from pathlib import Path
-from typing import Any
+from typing import Any, Iterable
 from uuid import uuid4
 
 import git
@@ -20,7 +18,6 @@ import requests
 import torch
 from loguru import logger
 from tqdm import tqdm
-from transformers import logging
 
 from hordelib.comfy_horde import (
     cleanup,
@@ -31,10 +28,8 @@ from hordelib.comfy_horde import (
 )
 from hordelib.comfy_horde import get_torch_device as _get_torch_device
 from hordelib.config_path import get_hordelib_path
-from hordelib.consts import REMOTE_MODEL_DB
+from hordelib.consts import MODEL_CATEGORY_NAMES, MODEL_DB_NAMES, MODEL_FOLDER_NAMES, REMOTE_MODEL_DB
 from hordelib.settings import UserSettings
-
-logging.set_verbosity_error()
 
 
 class BaseModelManager(ABC):
@@ -44,7 +39,6 @@ class BaseModelManager(ABC):
     available_models: list[str]  # XXX rework as a property?
     _loaded_models: dict[str, dict]
     """The models available for immediate use."""
-    tainted_models: list
     models_db_name: str
     models_db_path: Path
     cuda_available: bool
@@ -77,30 +71,26 @@ class BaseModelManager(ABC):
     def __init__(
         self,
         *,
-        models_db_name: str,  # XXX Remove default
-        modelFolder: str | None = None,
         download_reference: bool = False,
+        model_category_name: MODEL_CATEGORY_NAMES = MODEL_CATEGORY_NAMES.default_models,
     ):
         """Create a new instance of this model manager.
 
         Args:
-            models_db_name (str): The standard name for this model category. (e.g., 'clip')
+            model_category_name (MODEL_CATEGORY_NAMES): The category of model to manage.
             download_reference (bool, optional): Get the model DB from github. Defaults to False.
         """
-        if not modelFolder:
-            self.modelFolderPath = os.path.join(
-                UserSettings.get_model_directory(),
-                f"{models_db_name}",
-            )
-        else:  # XXX # FIXME The only exception to this right now is compvis
-            self.modelFolderPath = os.path.join(UserSettings.get_model_directory(), f"{modelFolder}")
+
+        self.modelFolderPath = os.path.join(
+            UserSettings.get_model_directory(),
+            f"{MODEL_FOLDER_NAMES[model_category_name]}",
+        )
 
         self.model_reference = {}
         self.available_models = []
         self._loaded_models = {}
-        self.tainted_models = []
         self.pkg = importlib_resources.files("hordelib")  # XXX Remove
-        self.models_db_name = models_db_name
+        self.models_db_name = MODEL_DB_NAMES[model_category_name]
         self.models_db_path = Path(get_hordelib_path()).joinpath(
             "model_database/",
             f"{self.models_db_name}.json",
@@ -303,13 +293,26 @@ class BaseModelManager(ABC):
         gpu_id: int | None = 0,
         cpu_only: bool = False,
         **kwargs,
-    ):  # XXX # FIXME
+    ) -> bool | None:
+        """Load a model into RAM.
+
+        Args:
+            model_name (str): The name of the model to load.
+            half_precision (bool, optional): Whether to use half precision. Defaults to True.
+            gpu_id (int | None, optional): The GPU to load into. Defaults to None.
+            cpu_only (bool, optional): Whether to only use CPU + System RAM. Defaults to False.
+            kwargs (dict[str, typing.Any]): Additional arguments.
+
+        Returns:
+            bool | None: `True` if the model was loaded, `False` if it failed to load/download,
+                `None` if the model name doesn't exist in the model reference.
+        """
         with self._mutex:
             self.ensure_ram_available()
             local = self.is_local_model(model_name)
             if not local and model_name not in self.model_reference:
                 logger.error(f"{model_name} not found")
-                return False
+                return None
             if not local and model_name not in self.available_models:
                 logger.warning(
                     f"{model_name} may need to be downloaded, checking...",
@@ -319,6 +322,9 @@ class BaseModelManager(ABC):
                     logger.error(f"{model_name} failed to download")
                     return False
                 logger.info(f"{model_name} Downloaded")
+            if model_name in self.get_loaded_models():
+                logger.debug(f"{model_name} is already loaded")
+                return True
             if model_name not in self.get_loaded_models():
                 if not local:
                     model_validated = self.validate_model(model_name)
@@ -344,13 +350,13 @@ class BaseModelManager(ABC):
                 except RuntimeError:
                     # It failed, it happens.
                     logger.error(f"Failed to load model {model_name}")
-                    return None
+                    return False
 
                 toc = time.time()
 
                 logger.info(f"Loaded {model_name}: {round(toc-tic,2)} seconds")
                 return True
-            return None
+        return False
 
     def getFullModelPath(self, model_name: str):
         """Returns the fully qualified filename for the specified model."""
@@ -410,7 +416,7 @@ class BaseModelManager(ABC):
         """
         return self.available_models
 
-    def get_available_models_by_types(self, model_types: list[str] | None = None):
+    def get_available_models_by_types(self, model_types: Iterable[str] | None = None):
         if not model_types:
             model_types = ["ckpt"]
         models_available = []
@@ -421,7 +427,7 @@ class BaseModelManager(ABC):
                 models_available.append(model)
         return models_available
 
-    def count_available_models_by_types(self, model_types: list[str] | None = None):
+    def count_available_models_by_types(self, model_types: Iterable[str] | None = None):
         return len(self.get_available_models_by_types(model_types))
 
     def get_loaded_model(self, model_name: str):
@@ -493,16 +499,6 @@ class BaseModelManager(ABC):
             for model in self.get_loaded_models():
                 self.unload_model(model)
             return True
-
-    def taint_model(self, model_name: str):
-        """Marks a model as not valid by removing it from available_models"""
-        if model_name in self.available_models:
-            self.available_models.remove(model_name)
-            self.tainted_models.append(model_name)
-
-    def taint_models(self, models: list[str]) -> None:
-        for model in models:
-            self.taint_model(model)
 
     def validate_model(self, model_name: str, skip_checksum: bool = False) -> bool | None:
         """Check the if the model file is on disk and, optionally, also if the checksum is correct.
@@ -802,7 +798,7 @@ class BaseModelManager(ABC):
         - unzip file
         """
         # XXX this function is wacky in its premise and needs to be reworked
-        if model_name in self.available_models and model_name not in self.tainted_models:
+        if model_name in self.available_models:
             logger.debug(f"{model_name} is already available.")
             return True
         download = self.get_model_download(model_name)
@@ -889,7 +885,7 @@ class BaseModelManager(ABC):
                 logger.info(f"delete {temp_path}")
                 shutil.rmtree(temp_path)
             else:
-                if not self.check_file_available(file_path) or model_name in self.tainted_models:
+                if not self.check_file_available(file_path):
                     logger.debug(f"Downloading {download_url} to {file_path}")
                     download_succeeded = self.download_file(download_url, file_path)
                     if not download_succeeded:

--- a/hordelib/model_manager/codeformer.py
+++ b/hordelib/model_manager/codeformer.py
@@ -10,7 +10,7 @@ from hordelib.model_manager.base import BaseModelManager
 class CodeFormerModelManager(BaseModelManager):
     def __init__(self, download_reference=False):
         super().__init__(
-            models_db_name=MODEL_DB_NAMES[MODEL_CATEGORY_NAMES.codeformer],
+            model_category_name=MODEL_CATEGORY_NAMES.codeformer,
             download_reference=download_reference,
         )
 

--- a/hordelib/model_manager/compvis.py
+++ b/hordelib/model_manager/compvis.py
@@ -8,7 +8,7 @@ from typing_extensions import override
 
 from hordelib import UserSettings
 from hordelib.comfy_horde import horde_load_checkpoint
-from hordelib.consts import MODEL_CATEGORY_NAMES, MODEL_DB_NAMES, MODEL_FOLDER_NAMES
+from hordelib.consts import MODEL_CATEGORY_NAMES
 from hordelib.model_manager.base import BaseModelManager
 
 
@@ -19,8 +19,7 @@ class CompVisModelManager(BaseModelManager):
         # custom_path="models/custom",  # XXX Remove this and any others like it?
     ):
         super().__init__(
-            modelFolder=MODEL_FOLDER_NAMES[MODEL_CATEGORY_NAMES.compvis],
-            models_db_name=MODEL_DB_NAMES[MODEL_CATEGORY_NAMES.compvis],
+            model_category_name=MODEL_CATEGORY_NAMES.compvis,
             download_reference=download_reference,
         )
 

--- a/hordelib/model_manager/controlnet.py
+++ b/hordelib/model_manager/controlnet.py
@@ -67,17 +67,15 @@ class ControlNetModelManager(BaseModelManager):
             return False
         if controlnet_name not in self.available_models:
             logger.error(f"{controlnet_name} not available")
-            logger.init_ok(
+            logger.info(
                 f"Downloading {controlnet_name}",
-                status="Downloading",
-            )  # logger.init_ok
+            )  # logger.info
             self.download_control_type(control_type, [model_baseline])
-            logger.init_ok(
+            logger.info(
                 f"{controlnet_name} downloaded",
-                status="Downloading",
-            )  # logger.init_ok
+            )
 
-        logger.init(f"{control_type}", status="Merging")  # logger.init
+        logger.info(f"Merging {control_type}")
         controlnet_path = os.path.join(
             self.modelFolderPath,
             self.get_controlnet_filename(controlnet_name),

--- a/hordelib/model_manager/controlnet.py
+++ b/hordelib/model_manager/controlnet.py
@@ -1,6 +1,7 @@
 import os
 import typing
 from enum import Enum
+from typing import Iterable
 
 from loguru import logger
 from typing_extensions import override
@@ -24,7 +25,7 @@ CONTROLNET_BASELINE_APPENDS: dict[CONTROLNET_BASELINE_NAMES | str, str] = {
 class ControlNetModelManager(BaseModelManager):
     def __init__(self, download_reference=False):
         super().__init__(
-            models_db_name=MODEL_DB_NAMES[MODEL_CATEGORY_NAMES.controlnet],
+            model_category_name=MODEL_CATEGORY_NAMES.controlnet,
             download_reference=download_reference,
         )
 
@@ -46,7 +47,7 @@ class ControlNetModelManager(BaseModelManager):
         control_type: str,
         model,
         model_baseline: str = CONTROLNET_BASELINE_NAMES.stable_diffusion_1,
-    ) -> tuple[typing.Any]:
+    ) -> tuple[typing.Any] | None:
         """Merge the specified control net with target model.
 
         Args:
@@ -64,7 +65,7 @@ class ControlNetModelManager(BaseModelManager):
             controlnet_name = "control_fakescribbles"
         if controlnet_name not in self.model_reference:
             logger.error(f"{controlnet_name} not found")
-            return False
+            return None
         if controlnet_name not in self.available_models:
             logger.error(f"{controlnet_name} not available")
             logger.info(
@@ -75,10 +76,11 @@ class ControlNetModelManager(BaseModelManager):
                 f"{controlnet_name} downloaded",
             )
 
+        controlnet_filename = self.get_controlnet_filename(controlnet_name)
         logger.info(f"Merging {control_type}")
         controlnet_path = os.path.join(
             self.modelFolderPath,
-            self.get_controlnet_filename(controlnet_name),
+            controlnet_filename if controlnet_filename else "",
         )
         controlnet = horde_load_controlnet(
             controlnet_path=controlnet_path,
@@ -89,7 +91,7 @@ class ControlNetModelManager(BaseModelManager):
     def download_control_type(
         self,
         control_type: str,
-        sd_baselines: list[str] | None = None,
+        sd_baselines: Iterable[str] | None = None,
     ) -> None:
         if sd_baselines is None:
             sd_baselines = [CONTROLNET_BASELINE_NAMES.stable_diffusion_1, CONTROLNET_BASELINE_NAMES.stable_diffusion_2]

--- a/hordelib/model_manager/diffusers.py
+++ b/hordelib/model_manager/diffusers.py
@@ -12,7 +12,7 @@ class DiffusersModelManager(BaseModelManager):
         raise NotImplementedError("Diffusers are not yet supported")
 
         super().__init__(
-            models_db_name=MODEL_DB_NAMES[MODEL_CATEGORY_NAMES.diffusers],
+            model_category_name=MODEL_CATEGORY_NAMES.diffusers,
             download_reference=download_reference,
         )
 

--- a/hordelib/model_manager/esrgan.py
+++ b/hordelib/model_manager/esrgan.py
@@ -11,7 +11,7 @@ from hordelib.model_manager.base import BaseModelManager
 class EsrganModelManager(BaseModelManager):
     def __init__(self, download_reference=False):
         super().__init__(
-            models_db_name=MODEL_DB_NAMES[MODEL_CATEGORY_NAMES.esrgan],
+            model_category_name=MODEL_CATEGORY_NAMES.esrgan,
             download_reference=download_reference,
         )
 

--- a/hordelib/model_manager/gfpgan.py
+++ b/hordelib/model_manager/gfpgan.py
@@ -11,7 +11,7 @@ from hordelib.model_manager.base import BaseModelManager
 class GfpganModelManager(BaseModelManager):
     def __init__(self, download_reference=False):
         super().__init__(
-            models_db_name=MODEL_DB_NAMES[MODEL_CATEGORY_NAMES.gfpgan],
+            model_category_name=MODEL_CATEGORY_NAMES.gfpgan,
             download_reference=download_reference,
         )
 

--- a/hordelib/model_manager/hyper.py
+++ b/hordelib/model_manager/hyper.py
@@ -355,9 +355,8 @@ class ModelManager:
             bool | None: The success of the load. If `None`, the model was not found.
         """
         if model_name in EXCLUDED_MODEL_NAMES:
-            logger.init_warn(
+            logger.warning(
                 f"{model_name} is excluded from loading at this time. If this is unexpected, let us know on discord.",
-                status="Skipping",
             )
             return False
 

--- a/hordelib/model_manager/hyper.py
+++ b/hordelib/model_manager/hyper.py
@@ -426,12 +426,26 @@ class ModelManager:
         if not mm_types:
             return []
 
+        if not isinstance(mm_types, list) and not isinstance(mm_types, tuple) and not isinstance(mm_types, set):
+            mm_types = [mm_types]  # type: ignore
+
         active_model_managers_types = [type(model_manager) for model_manager in self.active_model_managers]
 
         resolved_types = []
-        for mm_type in mm_types:
+        active_model_managers_types_names = [mm_type.__name__ for mm_type in active_model_managers_types]
+        for mm_type in mm_types:  # type: ignore
             if isinstance(mm_type, type) and mm_type in active_model_managers_types:
                 resolved_types.append(mm_type)
+                continue
+
+            if isinstance(mm_type, type) and mm_type.__name__ in active_model_managers_types_names:
+                resolved_types.append(mm_type)
+                logger.debug(
+                    (
+                        f"Found model manager by name: {mm_type.__name__}."
+                        " This may not be the model manager you are looking for.",
+                    ),
+                )
                 continue
 
             if not isinstance(mm_type, str) or mm_type not in MODEL_MANAGERS_TYPE_LOOKUP:

--- a/hordelib/model_manager/hyper.py
+++ b/hordelib/model_manager/hyper.py
@@ -2,6 +2,7 @@
 import copy
 import os
 import threading
+from typing import Iterable
 
 import torch
 from loguru import logger
@@ -33,23 +34,68 @@ MODEL_MANAGERS_TYPE_LOOKUP: dict[MODEL_CATEGORY_NAMES | str, type[BaseModelManag
     MODEL_CATEGORY_NAMES.blip: BlipModelManager,
     MODEL_CATEGORY_NAMES.clip: ClipModelManager,
 }
-"""Keys are `str` which represent attrs in `ModelManger`. Values are the corresponding `type`."""
+"""A lookup table for the `BaseModelManager` types."""
+
+ALL_MODEL_MANAGER_TYPES: list[type[BaseModelManager]] = list(MODEL_MANAGERS_TYPE_LOOKUP.values())
 
 
 class ModelManager:
     """Controller class for all managers which extend `BaseModelManager`."""
 
-    codeformer: CodeFormerModelManager | None = None
-    compvis: CompVisModelManager | None = None
-    controlnet: ControlNetModelManager | None = None
-    # diffusers: DiffusersModelManager | None = None
-    esrgan: EsrganModelManager | None = None
-    gfpgan: GfpganModelManager | None = None
-    safety_checker: SafetyCheckerModelManager | None = None
-    lora: LoraModelManager | None = None
-    blip: BlipModelManager | None = None
-    clip: ClipModelManager | None = None
-    # XXX I think this can be reworked into an array of BaseModelManager instances
+    # These properties are here with compatibility in mind, but they may survive for a while.
+    @property
+    def codeformer(self) -> CodeFormerModelManager | None:
+        """The CodeFormer model manager instance. Returns `None` if not loaded."""
+        found_mm = self.get_mm_pointer(CodeFormerModelManager)
+        return found_mm if isinstance(found_mm, CodeFormerModelManager) else None
+
+    @property
+    def compvis(self) -> CompVisModelManager | None:
+        """The CompVis model manager instance. Returns `None` if not loaded."""
+        found_mm = self.get_mm_pointer(CompVisModelManager)
+        return found_mm if isinstance(found_mm, CompVisModelManager) else None
+
+    @property
+    def controlnet(self) -> ControlNetModelManager | None:
+        """The ControlNet model manager instance. Returns `None` if not loaded."""
+        found_mm = self.get_mm_pointer(ControlNetModelManager)
+        return found_mm if isinstance(found_mm, ControlNetModelManager) else None
+
+    @property
+    def esrgan(self) -> EsrganModelManager | None:
+        """The ESRGAN model manager instance. Returns `None` if not loaded."""
+        found_mm = self.get_mm_pointer(EsrganModelManager)
+        return found_mm if isinstance(found_mm, EsrganModelManager) else None
+
+    @property
+    def gfpgan(self) -> GfpganModelManager | None:
+        """The GFPGAN model manager instance Returns `None` if not loaded.."""
+        found_mm = self.get_mm_pointer(GfpganModelManager)
+        return found_mm if isinstance(found_mm, GfpganModelManager) else None
+
+    @property
+    def safety_checker(self) -> SafetyCheckerModelManager | None:
+        """The SafetyChecker model manager instance. Returns `None` if not loaded."""
+        found_mm = self.get_mm_pointer(SafetyCheckerModelManager)
+        return found_mm if isinstance(found_mm, SafetyCheckerModelManager) else None
+
+    @property
+    def lora(self) -> LoraModelManager | None:
+        """The Lora model manager instance. Returns `None` if not loaded."""
+        found_mm = self.get_mm_pointer(LoraModelManager)
+        return found_mm if isinstance(found_mm, LoraModelManager) else None
+
+    @property
+    def blip(self) -> BlipModelManager | None:
+        """The Blip model manager instance. Returns `None` if not loaded."""
+        found_mm = self.get_mm_pointer(BlipModelManager)
+        return found_mm if isinstance(found_mm, BlipModelManager) else None
+
+    @property
+    def clip(self) -> ClipModelManager | None:
+        """The Clip model manager instance. Returns `None` if not loaded."""
+        found_mm = self.get_mm_pointer(ClipModelManager)
+        return found_mm if isinstance(found_mm, ClipModelManager) else None
 
     @property
     def models(self) -> dict:
@@ -68,8 +114,8 @@ class ModelManager:
 
     def get_available_models(
         self,
-        mm_include: list[str | MODEL_CATEGORY_NAMES | type[BaseModelManager]] | None = None,
-        mm_exclude: list[str | MODEL_CATEGORY_NAMES | type[BaseModelManager]] | None = None,
+        mm_include: Iterable[str | MODEL_CATEGORY_NAMES | type[BaseModelManager]] | None = None,
+        mm_exclude: Iterable[str | MODEL_CATEGORY_NAMES | type[BaseModelManager]] | None = None,
     ) -> list[str]:
         """All models for which information exists, and for which a download attempt could be made."""
         all_available_models: list[str] = []
@@ -78,7 +124,7 @@ class ModelManager:
         resolved_exclude_managers = self.get_mm_pointers(mm_exclude)
 
         for model_manager in self.active_model_managers:
-            if model_manager not in resolved_include_managers:
+            if resolved_include_managers and model_manager not in resolved_include_managers:
                 continue
             if model_manager in resolved_exclude_managers:
                 continue
@@ -91,8 +137,8 @@ class ModelManager:
 
     def get_loaded_models(
         self,
-        mm_include: list[str | MODEL_CATEGORY_NAMES | type[BaseModelManager]] | None = None,
-        mm_exclude: list[str | MODEL_CATEGORY_NAMES | type[BaseModelManager]] | None = None,
+        mm_include: Iterable[str | MODEL_CATEGORY_NAMES | type[BaseModelManager]] | None = None,
+        mm_exclude: Iterable[str | MODEL_CATEGORY_NAMES | type[BaseModelManager]] | None = None,
     ) -> dict[str, dict]:
         """All models for which have successfully loaded across all `BaseModelManager` types."""
         all_loaded_models: dict[str, dict] = {}
@@ -101,7 +147,7 @@ class ModelManager:
         resolved_exclude_managers = self.get_mm_pointers(mm_exclude)
 
         for model_manager in self.active_model_managers:
-            if model_manager not in resolved_include_managers:
+            if resolved_include_managers and model_manager not in resolved_include_managers:
                 continue
             if model_manager in resolved_exclude_managers:
                 continue
@@ -112,29 +158,7 @@ class ModelManager:
 
     loaded_models = property(get_loaded_models)
 
-    @property
-    def active_model_managers(self) -> list[BaseModelManager]:
-        """All loaded model managers."""
-        all_model_managers = [
-            self.compvis,
-            # self.diffusers,
-            self.esrgan,
-            self.gfpgan,
-            self.safety_checker,
-            self.codeformer,
-            self.controlnet,
-            self.lora,
-            self.blip,
-            self.clip,
-        ]
-        # reset available models
-
-        _active_model_managers: list[BaseModelManager] = []
-        for model_manager in all_model_managers:
-            if model_manager is not None:
-                _active_model_managers.append(model_manager)
-
-        return _active_model_managers
+    active_model_managers: list[BaseModelManager]
 
     def __init__(
         self,
@@ -146,6 +170,7 @@ class ModelManager:
         # We use this to serialise disk reads as no point in
         # doing more than one at a time as this will slow down the sequential read op.
         self.disk_read_mutex = threading.Lock()
+        self.active_model_managers = []
 
     def get_model_copy(self, model_name, model_component=None):
         if not model_component:
@@ -155,49 +180,57 @@ class ModelManager:
 
     def init_model_managers(
         self,
-        codeformer: bool = False,
-        compvis: bool = False,
-        controlnet: bool = False,
-        # diffusers: bool = False,
-        esrgan: bool = False,
-        gfpgan: bool = False,
-        safety_checker: bool = False,
-        lora: bool = False,
-        blip: bool = False,
-        clip: bool = False,
-    ):  # XXX are we married to the name and/or the idea behind this function
-        """For each arg which is true, attempt to load that `BaseModelManager` type."""
-        args_passed: dict = locals().copy()  # XXX This is temporary
-        args_passed.pop("self")  # XXX This is temporary
-
-        allModelMangerTypeKeys = MODEL_MANAGERS_TYPE_LOOKUP.keys()
-        # e.g. `MODEL_MANAGERS_TYPE_LOOKUP["compvis"]`` returns type `CompVisModelManager`
-
-        for argName, argValue in args_passed.items():
-            if not (argName in allModelMangerTypeKeys and hasattr(self, argName)):
-                raise Exception(f"{argName} is not a valid model manager type!")
-                # XXX better guarantees need to be made
-            if not argValue:
-                continue
-            if getattr(self, argName) is not None:
+        managers_to_load: Iterable[str | MODEL_CATEGORY_NAMES | type[BaseModelManager]],
+    ) -> None:
+        for manager_to_load in managers_to_load:
+            resolve_manager_to_load_type: type[BaseModelManager] | None = None
+            if isinstance(manager_to_load, type) and issubclass(manager_to_load, BaseModelManager):
+                if manager_to_load not in MODEL_MANAGERS_TYPE_LOOKUP.values():
+                    logger.warning(f"Attempted to load a model manager which doesn't exist: '{manager_to_load}'.")
+                    continue
+                resolve_manager_to_load_type = manager_to_load
+            elif manager_to_load in MODEL_MANAGERS_TYPE_LOOKUP.keys():
+                resolve_manager_to_load_type = MODEL_MANAGERS_TYPE_LOOKUP[manager_to_load]
+            else:
+                logger.warning(f"Attempted to load a model manager which doesn't exist: '{manager_to_load}'.")
                 continue
 
-            modelmanager = MODEL_MANAGERS_TYPE_LOOKUP[argName]
+            if any(mm for mm in self.active_model_managers if isinstance(mm, resolve_manager_to_load_type)):
+                logger.warning(
+                    f"Attempted to load a model manager which is already loaded: '{resolve_manager_to_load_type}'.",
+                )
+                continue
+            self.active_model_managers.append(resolve_manager_to_load_type())
 
-            # at runtime modelmanager() will be CompVisModelManager(), ClipModelManager(), etc
-            setattr(
-                self,
-                argName,
-                modelmanager(download_reference=False),
-            )  # XXX # FIXME # HACK
+    def unload_model_managers(
+        self,
+        managers_to_unload: Iterable[str | MODEL_CATEGORY_NAMES | type[BaseModelManager]],
+    ):
+        for manager_to_unload in managers_to_unload:
+            resolved_manager_to_unload_type: type[BaseModelManager] | None = None
+            if isinstance(manager_to_unload, type) and issubclass(manager_to_unload, BaseModelManager):
+                if manager_to_unload not in MODEL_MANAGERS_TYPE_LOOKUP.values():
+                    logger.warning(f"Attempted to unload a model manager which doesn't exist: '{manager_to_unload}'.")
+                    continue
+                resolved_manager_to_unload_type = manager_to_unload
+            elif manager_to_unload in MODEL_MANAGERS_TYPE_LOOKUP.keys():
+                resolved_manager_to_unload_type = MODEL_MANAGERS_TYPE_LOOKUP[manager_to_unload]
+            else:
+                logger.warning(f"Attempted to unload a model manager which doesn't exist: '{manager_to_unload}'.")
+                continue
+
+            if not [mm for mm in self.active_model_managers if isinstance(mm, resolved_manager_to_unload_type)]:
+                logger.warning(
+                    f"Attempted to unload a model manager which is not loaded: '{resolved_manager_to_unload_type}'.",
+                )
+                continue
+            self.active_model_managers = [
+                mm for mm in self.active_model_managers if not isinstance(mm, resolved_manager_to_unload_type)
+            ]
 
     def reload_database(self) -> None:
         """Completely resets the `BaseModelManager` classes, and forces each to re-init."""
-        model_managers: list[BaseModelManager] = []
-        for model_manager_type in MODEL_MANAGERS_TYPE_LOOKUP:
-            model_managers.append(getattr(self, model_manager_type))
-
-        for model_manager in model_managers:
+        for model_manager in self.active_model_managers:
             if model_manager is not None:
                 model_manager.loadModelDatabase()
 
@@ -211,7 +244,7 @@ class ModelManager:
             bool | None: The success of the download. If `None`, the model_name was not found.
         """
         for model_manager_type in MODEL_MANAGERS_TYPE_LOOKUP:
-            model_manager: BaseModelManager = getattr(self, model_manager_type)
+            model_manager: BaseModelManager | None = self.get_mm_pointer(model_manager_type)
             if model_manager is None:
                 continue
             if model_name not in model_manager.model_reference:
@@ -224,7 +257,7 @@ class ModelManager:
     def download_all(self) -> None:
         """Attempts to download all available models for all `BaseModelManager` types."""
         for model_manager_type in MODEL_MANAGERS_TYPE_LOOKUP:
-            model_manager: BaseModelManager = getattr(self, model_manager_type)
+            model_manager: BaseModelManager | None = self.get_mm_pointer(model_manager_type)
             if model_manager is None:
                 continue
 
@@ -244,26 +277,13 @@ class ModelManager:
         Returns:
             bool | None: The result of the validation. If `None`, the model was not found.
         """
-        for model_manager_type in MODEL_MANAGERS_TYPE_LOOKUP:
-            model_manager: BaseModelManager = getattr(self, model_manager_type)
+        for model_manager_type in MODEL_MANAGERS_TYPE_LOOKUP.values():
+            model_manager: BaseModelManager | None = self.get_mm_pointer(model_manager_type)
             if model_manager is None:
                 continue
             if model_name in model_manager.model_reference:
                 return model_manager.validate_model(model_name, skip_checksum)
         return None
-
-    def taint_models(self, models: list[str]) -> None:
-        """Marks a list of models to be unavailable.
-
-        Args:
-            models (list[str]): The list of models to mark.
-        """
-        for model_manager_type in MODEL_MANAGERS_TYPE_LOOKUP:
-            model_manager: BaseModelManager = getattr(self, model_manager_type)
-            if model_manager is None:
-                continue
-            if any(model in model_manager.model_reference for model in models):
-                model_manager.taint_models(models)
 
     def unload_model(self, model_name: str) -> bool | None:
         """Unloads the target model.
@@ -274,8 +294,8 @@ class ModelManager:
         Returns:
             bool | None: The result of the unloading. If `None`, the model was not found.
         """
-        for model_manager_type in MODEL_MANAGERS_TYPE_LOOKUP:
-            model_manager: BaseModelManager = getattr(self, model_manager_type)
+        for model_manager_type in MODEL_MANAGERS_TYPE_LOOKUP.values():
+            model_manager: BaseModelManager | None = self.get_mm_pointer(model_manager_type)
             if model_manager is None:
                 continue
             if model_name in model_manager.model_reference or model_manager.is_local_model(model_name):
@@ -292,7 +312,7 @@ class ModelManager:
             var (var): the var model data
         """
         for model_manager_type in MODEL_MANAGERS_TYPE_LOOKUP:
-            model_manager: BaseModelManager = getattr(self, model_manager_type)
+            model_manager: BaseModelManager | None = self.get_mm_pointer(model_manager_type)
             if model_manager is None:
                 continue
             if model_name in model_manager.model_reference or model_manager.is_local_model(model_name):
@@ -301,8 +321,8 @@ class ModelManager:
 
     def get_loaded_models_names(
         self,
-        mm_include: list[str | MODEL_CATEGORY_NAMES | type[BaseModelManager]] | None = None,
-        mm_exclude: list[str | MODEL_CATEGORY_NAMES | type[BaseModelManager]] | None = None,
+        mm_include: Iterable[str | MODEL_CATEGORY_NAMES | type[BaseModelManager]] | None = None,
+        mm_exclude: Iterable[str | MODEL_CATEGORY_NAMES | type[BaseModelManager]] | None = None,
     ) -> list:
         """
         Returns:
@@ -317,14 +337,14 @@ class ModelManager:
 
     def get_available_models_by_types(
         self,
-        mm_include: list[str | MODEL_CATEGORY_NAMES | type[BaseModelManager]] | None = None,
-        mm_exclude: list[str | MODEL_CATEGORY_NAMES | type[BaseModelManager]] | None = None,
+        mm_include: Iterable[str | MODEL_CATEGORY_NAMES | type[BaseModelManager]] | None = None,
+        mm_exclude: Iterable[str | MODEL_CATEGORY_NAMES | type[BaseModelManager]] | None = None,
     ):
         return self.get_available_models(mm_include, mm_exclude)
 
     def count_available_models_by_types(
         self,
-        model_types: list[str | MODEL_CATEGORY_NAMES | type[BaseModelManager]] | None = None,
+        model_types: Iterable[str | MODEL_CATEGORY_NAMES | type[BaseModelManager]] | None = None,
     ) -> int:
         return len(self.get_available_models_by_types(model_types))
 
@@ -333,7 +353,7 @@ class ModelManager:
         for model_manager_type in MODEL_MANAGERS_TYPE_LOOKUP:
             if specific_type and specific_type != model_manager_type:
                 continue
-            model_manager: BaseModelManager = getattr(self, model_manager_type)
+            model_manager: BaseModelManager | None = self.get_mm_pointer(model_manager_type)
             if model_manager is None:
                 continue
             model_manager.ensure_ram_available()
@@ -383,15 +403,22 @@ class ModelManager:
         logger.error(f"{model_name} not found")
         return None
 
+    def get_mm_pointer(
+        self,
+        mm_type: str | MODEL_CATEGORY_NAMES | type[BaseModelManager],
+    ) -> BaseModelManager | None:
+        found_manager = self.get_mm_pointers([mm_type])
+        return found_manager[0] if len(found_manager) > 0 else None
+
     def get_mm_pointers(
         self,
-        mm_types: list[str | MODEL_CATEGORY_NAMES | type[BaseModelManager]] | None = None,
+        mm_types: Iterable[str | MODEL_CATEGORY_NAMES | type[BaseModelManager]] | None = None,
     ) -> list[BaseModelManager]:
-        """Returns a set of model managers based on the input list of model manager types.
+        """Returns a set of model managers based on the input Iterable of model manager types.
 
         Args:
-            mm_types (list[str | MODEL_CATEGORY_NAMES | type[BaseModelManager]], optional): The list of model manager
-            types to resolve. Defaults to None.
+            mm_types (Iterable[str | MODEL_CATEGORY_NAMES | type[BaseModelManager]], optional): The Iterable of
+            model manager types to resolve. Defaults to None.
 
         Returns:
             list[BaseModelManager]: A list of the requested model managers.

--- a/hordelib/model_manager/lora.py
+++ b/hordelib/model_manager/lora.py
@@ -614,6 +614,9 @@ class LoraModelManager(BaseModelManager):
 
     def delete_lora_files(self, lora_filename: str):
         filename = os.path.join(self.modelFolderPath, lora_filename)
+        if not os.path.exists(filename):
+            logger.warning(f"Could not find LoRa file on disk to delete: {filename}")
+            return
         os.remove(filename)
         logger.info(f"Deleted LoRa file: {filename}")
 

--- a/hordelib/model_manager/lora.py
+++ b/hordelib/model_manager/lora.py
@@ -735,7 +735,7 @@ class LoraModelManager(BaseModelManager):
             return None
         return datetime.strptime(lora["last_used"], "%Y-%m-%d %H:%M:%S")
 
-    def fetch_adhoc_lora(self, lora_name, timeout=30):
+    def fetch_adhoc_lora(self, lora_name, timeout=45):
         if type(lora_name) is int or lora_name.isdigit():
             url = f"https://civitai.com/api/v1/models/{lora_name}"
         else:

--- a/hordelib/model_manager/safety_checker.py
+++ b/hordelib/model_manager/safety_checker.py
@@ -14,7 +14,7 @@ from hordelib.model_manager.base import BaseModelManager
 class SafetyCheckerModelManager(BaseModelManager):
     def __init__(self, download_reference=False):
         super().__init__(
-            models_db_name=MODEL_DB_NAMES[MODEL_CATEGORY_NAMES.safety_checker],
+            model_category_name=MODEL_CATEGORY_NAMES.safety_checker,
             download_reference=download_reference,
         )
 

--- a/hordelib/preload.py
+++ b/hordelib/preload.py
@@ -14,27 +14,24 @@ def validate_all_controlnet_annotators(annotatorPath: Path) -> bool:
         annotator_full_path = annotatorPath.joinpath(annotator)
 
         if annotator not in ANNOTATOR_MODEL_SHA_LOOKUP:
-            logger.init_warn(
+            logger.warning(
                 f"Annotator file {annotator} is not in the model database. Ignoring...",
-                status="Warning",
             )
-            logger.init_warn(f"File location: {annotator_full_path}", status="Warning")
+            logger.warning(f"File location: {annotator_full_path}")
             continue
 
         hash = BaseModelManager.get_file_sha256_hash(annotator_full_path)
         if hash != ANNOTATOR_MODEL_SHA_LOOKUP[annotator]:
             try:
                 annotator_full_path.unlink()
-                logger.init_err(
+                logger.error(
                     f"Deleted annotator file {annotator} as it was corrupt.",
-                    status="Error",
                 )
             except OSError:
-                logger.init_err(
+                logger.error(
                     f"Annotator file {annotator} is corrupt. Please delete it and try again.",
-                    status="Error",
                 )
-                logger.init_err(f"File location: {annotator_full_path}", status="Error")
+                logger.error(f"File location: {annotator_full_path}")
             return False
     return True
 

--- a/hordelib/shared_model_manager.py
+++ b/hordelib/shared_model_manager.py
@@ -26,9 +26,8 @@ def do_migrations():
     sd_inpainting_v1_5_ckpt = diffusers_dir.joinpath("sd-v1-5-inpainting.ckpt").resolve()
     sd_inpainting_v1_5_sha256 = diffusers_dir.joinpath("sd-v1-5-inpainting.sha256").resolve()
     if diffusers_dir.exists() and sd_inpainting_v1_5_ckpt.exists():
-        logger.init_warn(
+        logger.warning(
             "stable_diffusion_inpainting found in diffusers folder and is being moved to compvis",
-            status="Warning",
         )
 
         target_ckpt_path = (
@@ -43,16 +42,14 @@ def do_migrations():
             if sd_inpainting_v1_5_sha256.exists():
                 sd_inpainting_v1_5_sha256.rename(target_sha_path)
         except OSError as e:
-            logger.init_err(
+            logger.error(
                 f"Failed to move {sd_inpainting_v1_5_ckpt} to {target_ckpt_path}. {e}",
-                status="Error",
             )
-            logger.init_err("Please move this file manually and try again.", status="Error")
+            logger.error("Please move this file manually and try again.")
             return
 
-        logger.init_warn(
+        logger.warning(
             "stable_diffusion_inpainting successfully moved to compvis. The diffusers directory can now be deleted.",
-            status="Warning",
         )
 
 
@@ -100,16 +97,14 @@ class SharedModelManager:
                     f.write(file_path.read_bytes())
             except OSError as e:
                 if hordelib_model_db_path.is_symlink():
-                    logger.init_err("Failed to unlink symlink.", status="Error")
-                    logger.init_err(f"Please delete the symlink at {hordelib_model_db_path} and try again.")
+                    logger.error("Failed to unlink symlink.")
+                    logger.error(f"Please delete the symlink at {hordelib_model_db_path} and try again.")
                 else:
-                    logger.init_err(
+                    logger.error(
                         f"Failed to copy {file_path} to {hordelib_model_db_path}.",
-                        status="Error",
                     )
-                    logger.init_err(
+                    logger.error(
                         f"If you continue to get this error, please delete {hordelib_model_db_path}.",
-                        status="Error",
                     )
                 raise e
         do_migrations()
@@ -146,9 +141,8 @@ class SharedModelManager:
         annotators_in_legacy_directory = Path(builtins.annotator_ckpts_path).glob("*.pt*")
 
         for legacy_annotator in annotators_in_legacy_directory:
-            logger.init_warn("Annotator found in legacy directory. This file can be safely deleted:", status="Warning")
-            logger.init_warn(f"{legacy_annotator}", status="Warning")
-            logger.init_warn("", status="Warning")
+            logger.warning("Annotator found in legacy directory. This file can be safely deleted:")
+            logger.warning(f"{legacy_annotator}")
 
         builtins.annotator_ckpts_path = (
             Path(UserSettings.get_model_directory()).joinpath("controlnet").joinpath("annotator").joinpath("ckpts")
@@ -165,17 +159,21 @@ class SharedModelManager:
         # by downloading them below.
         validate_all_controlnet_annotators(builtins.annotator_ckpts_path)
 
-        logger.init("Attempting to preload all controlnet annotators.", status="Loading")
-        logger.init("This may take several minutes...", status="Loading")
+        logger.info(
+            "Attempting to preload all controlnet annotators.",
+        )
+        logger.info(
+            "This may take several minutes...",
+        )
 
         annotators_downloaded_successfully = download_all_controlnet_annotators()
         if not annotators_downloaded_successfully:
-            logger.init_err("Failed to download one or more annotators.", status="Error")
+            logger.error("Failed to download one or more annotators.")
             return False
 
         annotators_all_validated_successfully = validate_all_controlnet_annotators(builtins.annotator_ckpts_path)
         if not annotators_all_validated_successfully:
-            logger.init_err("Failed to validate one or more annotators.", status="Error")
+            logger.error("Failed to validate one or more annotators.")
             return False
 
         return True

--- a/hordelib/shared_model_manager.py
+++ b/hordelib/shared_model_manager.py
@@ -84,7 +84,7 @@ class SharedModelManager:
         passed_args = locals().copy()
         passed_args.pop("cls")
         for passed_arg, value in passed_args.items():
-            if value and passed_arg in MODEL_REFERENCE_CATEGORIES:
+            if value and passed_arg in MODEL_CATEGORY_NAMES.__members__.values():
                 managers_to_load.append(passed_arg)
 
         logger.debug(f"Redownloading all model databases to {get_hordelib_path()}.")

--- a/hordelib/utils/distance.py
+++ b/hordelib/utils/distance.py
@@ -88,7 +88,7 @@ class HistogramDistanceResultCode(float, Enum):
     # Note: The values must be in descending value order, as the first value is used as the default value.
     # (closer to 0 is more similar, higher values are a greater distance (more potential for being dissimilar))
     COMPLETELY_DISSIMILAR_DISTRIBUTION = 100000
-    """The color distributions are completely different, and there is a very high potential for the two images to 
+    """The color distributions are completely different, and there is a very high potential for the two images to
     have completely different compositions."""
     VERY_DISSIMILAR_DISTRIBUTION = 70000
     """The color distributions are very similar, and there is a very high potential for them to be perceptually

--- a/hordelib/utils/logger.py
+++ b/hordelib/utils/logger.py
@@ -6,17 +6,14 @@ from loguru import logger
 
 
 class HordeLog:
-    STDOUT_LEVELS = ["GENERATION", "PROMPT"]
-    INIT_LEVELS = ["INIT", "INIT_OK", "INIT_WARN", "INIT_ERR"]
-    MESSAGE_LEVELS = ["MESSAGE"]
-    STATS_LEVELS = ["STATS"]
-
     # By default we're at error level or higher
     verbosity = 20
     quiet = 0
 
+    CUSTOM_STATS_LEVELS = ["STATS"]
+
     # Our sink IDs
-    sinks = []
+    sinks: list[int] = []  # default mutable because this is a class variable (class is a singleton)
 
     @classmethod
     def set_logger_verbosity(cls, count):
@@ -31,76 +28,47 @@ class HordeLog:
         cls.quiet = count * 10
 
     @classmethod
-    def is_stdout_log(cls, record):
-        if record["level"].name not in HordeLog.STDOUT_LEVELS:
-            return False
-        if record["level"].no < cls.verbosity + cls.quiet:
-            return False
-        return True
-
-    @classmethod
-    def is_init_log(cls, record):
-        if record["level"].name not in HordeLog.INIT_LEVELS:
-            return False
-        if record["level"].no < cls.verbosity + cls.quiet:
-            return False
-        return True
-
-    @classmethod
-    def is_msg_log(cls, record):
-        if record["level"].name not in HordeLog.MESSAGE_LEVELS:
-            return False
-        if record["level"].no < cls.verbosity + cls.quiet:
-            return False
-        return True
-
-    @classmethod
-    def is_stderr_log(cls, record):
-        if (
-            record["level"].name
-            in HordeLog.STDOUT_LEVELS + HordeLog.INIT_LEVELS + HordeLog.MESSAGE_LEVELS + HordeLog.STATS_LEVELS
-        ):
-            return False
-        if record["level"].no < cls.verbosity + cls.quiet:
-            return False
-        return True
-
-    @classmethod
     def is_stats_log(cls, record):
-        if record["level"].name not in HordeLog.STATS_LEVELS:
+        if record["level"].name not in HordeLog.CUSTOM_STATS_LEVELS:
             return False
         return True
 
     @classmethod
     def is_not_stats_log(cls, record):
-        if record["level"].name in HordeLog.STATS_LEVELS:
+        if record["level"].name in HordeLog.CUSTOM_STATS_LEVELS:
+            return False
+        return True
+
+    @classmethod
+    def is_stderr_log(cls, record):
+        if record["level"].name not in ["ERROR", "CRITICAL", "TRACE"]:
             return False
         return True
 
     @classmethod
     def is_trace_log(cls, record):
-        if record["level"].name not in ["TRACE", "ERROR"]:
+        if record["level"].name != "ERROR":
             return False
         return True
 
     @classmethod
     def test_logger(cls):
-        logger.generation(
-            "This is a generation message\nIt is typically multiline\nThee Lines".encode(
-                "unicode_escape",
-            ).decode("utf-8"),
-        )
-        logger.prompt("This is a prompt message")
         logger.debug("Debug Message")
         logger.info("Info Message")
         logger.warning("Info Warning")
         logger.error("Error Message")
         logger.critical("Critical Message")
-        logger.init("This is an init message", status="Starting")
-        logger.init_ok("This is an init message", status="OK")
-        logger.init_warn("This is an init message", status="Warning")
-        logger.init_err("This is an init message", status="Error")
-        logger.message("This is user message")
+
+        logger.log("STATS", "Stats Message")
+
+        a = 0
+
+        @logger.catch
+        def main():
+            a.item()  # This will raise an exception
+
+        main()
+
         sys.exit()
 
     @classmethod
@@ -108,59 +76,13 @@ class HordeLog:
         if setup_logging:
             cls.setup()
             cls.set_sinks()
-        else:
-            cls.setup_compatibility()
 
         logger.disable("hordelib.clip.interrogate")
 
     @classmethod
-    def setup_compatibility(cls):
-        logger.__class__.generation = partialmethod(logger.__class__.log, "INFO")
-        logger.__class__.prompt = partialmethod(logger.__class__.log, "INFO")
-        logger.__class__.init = partialmethod(logger.__class__.log, "INFO")
-        logger.__class__.init_ok = partialmethod(logger.__class__.log, "INFO")
-        logger.__class__.init_warn = partialmethod(logger.__class__.log, "INFO")
-        logger.__class__.init_err = partialmethod(logger.__class__.log, "ERROR")
-        logger.__class__.message = partialmethod(logger.__class__.log, "INFO")
-        logger.__class__.stats = partialmethod(logger.__class__.log, "DEBUG")
-
-    @classmethod
     def setup(cls):
-        cls.logfmt = (
-            "<level>{level: <10}</level> | <green>{time:YYYY-MM-DD HH:mm:ss.SSSSSS}</green> | "
-            "<green>{name}</green>:<green>{function}</green>:<green>{line}</green> - <level>{message}</level>"
-        )
-        cls.genfmt = (
-            "<level>{level: <10}</level> @ <green>{time:YYYY-MM-DD HH:mm:ss.SSSSSS}</green> | <level>{message}</level>"
-        )
-        cls.initfmt = (
-            "<magenta>INIT      </magenta> | <level>{extra[status]: <11}</level> | <magenta>{message}</magenta>"
-        )
-        cls.msgfmt = "<level>{level: <10}</level> | <level>{message}</level>"
-
-        try:
-            logger.level("GENERATION", no=24, color="<cyan>")
-            logger.level("PROMPT", no=23, color="<yellow>")
-            logger.level("INIT", no=31, color="<white>")
-            logger.level("INIT_OK", no=31, color="<green>")
-            logger.level("INIT_WARN", no=31, color="<yellow>")
-            logger.level("INIT_ERR", no=31, color="<red>")
-            # Messages contain important information without which this application might not be able to be used
-            # As such, they have the highest priority
-            logger.level("MESSAGE", no=61, color="<green>")
-            # Stats are info that might not display well in the terminal
-            logger.level("STATS", no=19, color="<blue>")
-        except TypeError:
-            pass
-
-        logger.__class__.generation = partialmethod(logger.__class__.log, "GENERATION")
-        logger.__class__.prompt = partialmethod(logger.__class__.log, "PROMPT")
-        logger.__class__.init = partialmethod(logger.__class__.log, "INIT")
-        logger.__class__.init_ok = partialmethod(logger.__class__.log, "INIT_OK")
-        logger.__class__.init_warn = partialmethod(logger.__class__.log, "INIT_WARN")
-        logger.__class__.init_err = partialmethod(logger.__class__.log, "INIT_ERR")
-        logger.__class__.message = partialmethod(logger.__class__.log, "MESSAGE")
-        logger.__class__.stats = partialmethod(logger.__class__.log, "STATS")
+        for level in cls.CUSTOM_STATS_LEVELS:
+            logger.level(level, no=cls.verbosity + cls.quiet)
 
     @classmethod
     def set_sinks(cls):
@@ -176,55 +98,29 @@ class HordeLog:
             "handlers": [
                 {
                     "sink": sys.stderr,
-                    "format": cls.logfmt,
                     "colorize": True,
                     "filter": cls.is_stderr_log,
                 },
                 {
                     "sink": sys.stdout,
-                    "format": cls.genfmt,
-                    "level": "PROMPT",
                     "colorize": True,
-                    "filter": cls.is_stdout_log,
-                },
-                {
-                    "sink": sys.stdout,
-                    "format": cls.initfmt,
-                    "level": "INIT",
-                    "colorize": True,
-                    "filter": cls.is_init_log,
-                },
-                {
-                    "sink": sys.stdout,
-                    "format": cls.msgfmt,
-                    "level": "MESSAGE",
-                    "colorize": True,
-                    "filter": cls.is_msg_log,
                 },
                 {
                     "sink": "logs/bridge.log",
-                    "format": cls.logfmt,
                     "level": "DEBUG",
-                    "colorize": False,
-                    "filter": cls.is_not_stats_log,
                     "retention": "2 days",
                     "rotation": "1 days",
                 },
                 {
                     "sink": "logs/stats.log",
-                    "format": cls.logfmt,
                     "level": "STATS",
-                    "colorize": False,
                     "filter": cls.is_stats_log,
                     "retention": "7 days",
                     "rotation": "1 days",
                 },
                 {
                     "sink": "logs/trace.log",
-                    "format": cls.logfmt,
-                    "level": "TRACE",
-                    "colorize": False,
-                    "filter": cls.is_trace_log,
+                    "level": "ERROR",
                     "retention": "3 days",
                     "rotation": "1 days",
                     "backtrace": True,

--- a/mypy.ini
+++ b/mypy.ini
@@ -6,3 +6,9 @@ ignore_missing_imports = True
 
 [mypy-clipfree.*]
 ignore_missing_imports = True
+
+[mypy-horde_model_reference.*]
+ignore_missing_imports = True
+
+[mypy-fuzzywuzzy.*]
+ignore_missing_imports = True

--- a/mypy.ini
+++ b/mypy.ini
@@ -1,2 +1,8 @@
 [mypy]
-exclude = (ComfyUI|comfy_controlnet_preprocessors|facerestore|comfy_horde)
+exclude = (ComfyUI|comfy_controlnet_preprocessors|facerestore|comfy_horde|examples)
+
+[mypy-xformers.*]
+ignore_missing_imports = True
+
+[mypy-clipfree.*]
+ignore_missing_imports = True

--- a/mypy.ini
+++ b/mypy.ini
@@ -1,0 +1,2 @@
+[mypy]
+exclude = (ComfyUI|comfy_controlnet_preprocessors|facerestore|comfy_horde)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -41,7 +41,7 @@ license-files = ["LICENSE", "CHANGELOG*"]
 dependencies = {file = ["requirements.txt"]}
 
 [tool.setuptools.packages.find]
-exclude = ["ComfyUI"]
+exclude = ["ComfyUI", "build"]
 namespaces = false
 
 [options.index-client]
@@ -120,10 +120,3 @@ select = [
 "run_stress_test.py" = ["F841"]
 
 
-[tool.mypy]
-exclude = '''(?x)(
-    ComfyUI
-  | \.tox
-  | comfy_controlnet_preprocessors
-  | facerestore
-)''' # If you change this, you probably need to also change [tool.black] above

--- a/requirements.txt
+++ b/requirements.txt
@@ -40,4 +40,4 @@ scikit-image
 mediapipe>=0.9.1.0
 unidecode
 fuzzywuzzy
-horde_clipfree
+horde_clipfree>=0.0.2

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -3,7 +3,8 @@ import pytest
 
 from hordelib.comfy_horde import Comfy_Horde
 from hordelib.horde import HordeLib
-from hordelib.shared_model_manager import SharedModelManager
+from hordelib.model_manager.compvis import CompVisModelManager
+from hordelib.shared_model_manager import ALL_MODEL_MANAGER_TYPES, SharedModelManager
 
 
 @pytest.fixture(scope="session")
@@ -33,17 +34,8 @@ def isolated_comfy_horde_instance(init_horde) -> Comfy_Horde:
 @pytest.fixture(scope="class")
 def shared_model_manager(hordelib_instance: HordeLib) -> type[SharedModelManager]:
     SharedModelManager()
-    SharedModelManager.loadModelManagers(
-        codeformer=True,
-        compvis=True,
-        controlnet=True,
-        esrgan=True,
-        gfpgan=True,
-        safety_checker=True,
-        lora=True,
-        blip=True,
-        clip=True,
-    )
+    SharedModelManager.load_model_managers(ALL_MODEL_MANAGER_TYPES)
+
     assert SharedModelManager._instance is not None
     assert SharedModelManager.manager is not None
     assert SharedModelManager.manager.codeformer is not None
@@ -66,7 +58,7 @@ def shared_model_manager(hordelib_instance: HordeLib) -> type[SharedModelManager
 def stable_diffusion_modelname_for_testing(shared_model_manager: type[SharedModelManager]) -> str:
     """Loads the stable diffusion model for testing. This model is used by many tests.
     This fixture returns the model name as string."""
-    shared_model_manager.loadModelManagers(compvis=True)
+    shared_model_manager.load_model_managers([CompVisModelManager])
     model_name = "Deliberate"
     assert shared_model_manager.manager.load(model_name)
     return model_name

--- a/tests/test_blip.py
+++ b/tests/test_blip.py
@@ -9,10 +9,7 @@ from hordelib.shared_model_manager import SharedModelManager
 class TestHordeBlip:
     @pytest.fixture(autouse=True)
     def setup_and_teardown(self, shared_model_manager: type[SharedModelManager]):
-        default_model_manager_args = {
-            "blip": True,
-        }
-        shared_model_manager.loadModelManagers(**default_model_manager_args)
+        shared_model_manager.load_model_managers(["blip"])
         shared_model_manager.manager.load("BLIP_Large")
         assert shared_model_manager.manager.is_model_loaded("BLIP_Large") is True
         yield

--- a/tests/test_clip.py
+++ b/tests/test_clip.py
@@ -14,10 +14,7 @@ class TestHordeClip:
 
     @pytest.fixture(autouse=True, scope="class")
     def setup_and_teardown(self, shared_model_manager: type[SharedModelManager]):
-        default_model_manager_args = {
-            "clip": True,
-        }
-        shared_model_manager.loadModelManagers(**default_model_manager_args)
+        shared_model_manager.load_model_managers(["clip"])
         shared_model_manager.manager.load("ViT-L/14")
         assert shared_model_manager.manager.is_model_loaded("ViT-L/14") is True
         yield

--- a/tests/test_horde_inference_controlnet.py
+++ b/tests/test_horde_inference_controlnet.py
@@ -217,7 +217,7 @@ class TestHordeInference:
         pil_image = hordelib_instance.basic_inference(data)
         assert pil_image is not None
 
-        img_filename = f"controlnet_image_is_control.png"
+        img_filename = "controlnet_image_is_control.png"
 
         pil_image.save(f"images/{img_filename}", quality=100)
         images_to_compare.append((f"images_expected/{img_filename}", pil_image))

--- a/tests/testing_shared_functions.py
+++ b/tests/testing_shared_functions.py
@@ -1,7 +1,8 @@
+import json
 from dataclasses import dataclass
 from enum import Enum, auto
 from pathlib import Path
-from typing import TypeVar
+from typing import Iterable, TypeVar
 
 import PIL.Image
 import pytest
@@ -165,7 +166,7 @@ def check_single_lora_image_similarity(
 
 
 def check_list_lora_images_similarity(
-    list_of_image_pairs: list[tuple[FilePathOrPILImage, FilePathOrPILImage]],
+    list_of_image_pairs: Iterable[tuple[FilePathOrPILImage, FilePathOrPILImage]],
 ) -> bool:
 
     return check_list_images_similarity(
@@ -175,7 +176,7 @@ def check_list_lora_images_similarity(
 
 
 def check_list_inference_images_similarity(
-    list_of_image_pairs: list[tuple[FilePathOrPILImage, FilePathOrPILImage]],
+    list_of_image_pairs: Iterable[tuple[FilePathOrPILImage, FilePathOrPILImage]],
 ) -> bool:
 
     return check_list_images_similarity(
@@ -185,7 +186,7 @@ def check_list_inference_images_similarity(
 
 
 def check_list_images_similarity(
-    list_of_image_pairs: list[tuple[FilePathOrPILImage, FilePathOrPILImage]],
+    list_of_image_pairs: Iterable[tuple[FilePathOrPILImage, FilePathOrPILImage]],
     *,
     similarity_constraints: ImageSimilarityConstraints,
 ) -> bool:

--- a/tests/testing_shared_functions.py
+++ b/tests/testing_shared_functions.py
@@ -54,8 +54,8 @@ class ImageSimilarityResultCode(Enum):
 @dataclass
 class ImageSimilarityResult:
     result_code: ImageSimilarityResultCode
-    cosine_similarity_result: float
-    histogram_distance_result: float
+    cosine_similarity_result: CosineSimilarityResultCode | float
+    histogram_distance_result: HistogramDistanceResultCode | float
 
 
 def check_image_similarity_pytest(


### PR DESCRIPTION
Of note: 
- `loadModelManagers` deprecated, replaced by `load_model_managers `
- `load_model_managers` expects `Iterable[str | MODEL_CATEGORY_NAMES | type[BaseModelManager]` instead of keyword arguments
- Adhoc LoRa fetch time increased to 45 seconds
- Utilizes the changes in https://github.com/Haidra-Org/horde-model-reference/pull/29 to use `AIWORKER_CACHE_HOME` to as the location to store model reference files
- Removes the loguru hijack's (`init_ok`, etc). The worker side still has them, and in practice I cannot discern the difference. I know this may be a contentious choice.
- Better type hints

Everything should be largely backwards compatible if third parties happen to be using this library.