### PR TITLE
fix: taint models readded, more accurate dependency reqs

### DIFF
--- a/hordelib/model_manager/hyper.py
+++ b/hordelib/model_manager/hyper.py
@@ -285,6 +285,19 @@ class ModelManager:
                 return model_manager.validate_model(model_name, skip_checksum)
         return None
 
+    def taint_models(self, models: list[str]) -> None:
+        """Marks a list of models to be unavailable.
+
+        Args:
+            models (list[str]): The list of models to mark.
+        """
+        for model_manager_type in MODEL_MANAGERS_TYPE_LOOKUP:
+            model_manager: BaseModelManager = getattr(self, model_manager_type)
+            if model_manager is None:
+                continue
+            if any(model in model_manager.model_reference for model in models):
+                model_manager.taint_models(models)
+
     def unload_model(self, model_name: str) -> bool | None:
         """Unloads the target model.
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 # Add this in for tox, comment out for build
 --extra-index-url https://download.pytorch.org/whl/cu118
-horde_model_reference>=0.1.1
+horde_model_reference~=0.2.0
 pydantic
 torch>=2.0.0
 xformers>=0.0.19
@@ -40,4 +40,4 @@ scikit-image
 mediapipe>=0.9.1.0
 unidecode
 fuzzywuzzy
-horde_clipfree>=0.0.2
+horde_clipfree==0.0.2


### PR DESCRIPTION
In the menagerie of changes I made in various working branches, I missed that I had resolved out the merges to remove taint. Its potential use and benefit is clearer to me now, and it should have been included (#19 indicates as much).

This reverses this mistake and hard pins `horde_clipfree`, which while I hope that is the last version of that package, may mitigate future compatibility problems if more breaking changes are needed.